### PR TITLE
Fix build on nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,7 +290,7 @@ impl Binding for CmarkOptions {
 }
 
 pub fn cmark_version() -> i32 {
-    raw::cmark_version as i32
+    unsafe { raw::cmark_version as i32 }
 }
 
 pub fn version<'a>() -> &'a str {


### PR DESCRIPTION
Hi.

https://github.com/rust-lang/rust/pull/42894 makes some compatibility lints in `rustc` deny-by-default and regression testing found that this crate is affected. Here's a patch fixing the deprecated code (see https://github.com/rust-lang/rust/issues/36247 for more information about the issue).
